### PR TITLE
Replaced list by queue

### DIFF
--- a/include/tinyevents/tinyevents.hpp
+++ b/include/tinyevents/tinyevents.hpp
@@ -79,7 +79,7 @@ namespace tinyevents
 
         void process() {
             while (!queuedDispatches.empty()) {
-                std::function<void(Dispatcher&)> queuedDispatch = queuedDispatches.front();
+                std::function<void(Dispatcher&)> queuedDispatch = std::move(queuedDispatches.front());
                 queuedDispatches.pop();
                 queuedDispatch(*this);
             }

--- a/include/tinyevents/tinyevents.hpp
+++ b/include/tinyevents/tinyevents.hpp
@@ -71,9 +71,9 @@ namespace tinyevents
         }
 
         template<typename T>
-        void queue(const T &msg) {
-            queuedDispatches.push([msg](Dispatcher& dispatcher) {
-                dispatcher.dispatch(msg);
+        void queue(T&& msg) {
+            queuedDispatches.push([m = std::forward<T>(msg)](Dispatcher& dispatcher) {
+                dispatcher.dispatch(m);
             });
         }
 

--- a/include/tinyevents/tinyevents.hpp
+++ b/include/tinyevents/tinyevents.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <functional>
-#include <list>
+#include <queue>
 #include <set>
 #include <map>
 #include <typeindex>
@@ -72,16 +72,17 @@ namespace tinyevents
 
         template<typename T>
         void queue(const T &msg) {
-            queuedDispatches.push_back([msg](Dispatcher& dispatcher) {
+            queuedDispatches.push([msg](Dispatcher& dispatcher) {
                 dispatcher.dispatch(msg);
             });
         }
 
         void process() {
-            for (auto &queuedDispatch: queuedDispatches) {
+            while (!queuedDispatches.empty()) {
+                std::function<void(Dispatcher&)> queuedDispatch = queuedDispatches.front();
+                queuedDispatches.pop();
                 queuedDispatch(*this);
             }
-            queuedDispatches.clear();
         }
 
         void remove(const std::uint64_t handle) {
@@ -110,7 +111,7 @@ namespace tinyevents
         }
 
         std::map<std::type_index, Listeners> listenersByType;
-        std::list<std::function<void(Dispatcher&)>> queuedDispatches;
+        std::queue<std::function<void(Dispatcher&)>> queuedDispatches;
         std::set<ListenerHandle> listenersScheduledForRemoval;
 
         std::uint64_t nextListenerId = 0;

--- a/tests/TestEventQueue.cpp
+++ b/tests/TestEventQueue.cpp
@@ -14,8 +14,13 @@ TEST_F(TestEventQueue, MessagesQueuedAndThenIgnoredWhenNoListeners) {
     dispatcher.queue(123.0f);
     dispatcher.queue("abc");
 
+    // Dispatch by rvalue
     struct CustomType { };
     dispatcher.queue(CustomType{});
+
+    // Dispatch by lvalue
+    CustomType customType;
+    dispatcher.queue(customType);
 
     dispatcher.process();
 }

--- a/tests/TestEventQueue.cpp
+++ b/tests/TestEventQueue.cpp
@@ -65,3 +65,23 @@ TEST_F(TestEventQueue, MessageQeuedBeforeListenerAddedAndThenSent) {
     EXPECT_CALL(intCallback, Call(123)).Times(1);
     dispatcher.process();
 }
+
+TEST_F(TestEventQueue, MessageQueuedDataGoesOutOfScope) {
+    StrictMock<MockFunction<void(const int &)>> intCallback;
+
+    {
+        int i = 123;
+        dispatcher.queue(i);
+    }
+
+    {
+        int i = 456;
+        dispatcher.queue(i);
+    }
+
+    dispatcher.listen(intCallback.AsStdFunction());
+
+    EXPECT_CALL(intCallback, Call(123)).Times(1);
+    EXPECT_CALL(intCallback, Call(456)).Times(1);
+    dispatcher.process();
+}

--- a/tests/TestEventQueue.cpp
+++ b/tests/TestEventQueue.cpp
@@ -85,3 +85,20 @@ TEST_F(TestEventQueue, MessageQueuedDataGoesOutOfScope) {
     EXPECT_CALL(intCallback, Call(456)).Times(1);
     dispatcher.process();
 }
+
+TEST_F(TestEventQueue, MessageQueueInsideQueuedListener) {
+    StrictMock<MockFunction<void(const int &)>> intCallback;
+
+    dispatcher.listen<int>([&](const int &msg) {
+        if (msg == 123) {
+            dispatcher.queue(456);
+        }
+    });
+
+    dispatcher.listen(intCallback.AsStdFunction());
+
+    EXPECT_CALL(intCallback, Call(123)).Times(1);
+    EXPECT_CALL(intCallback, Call(456)).Times(1);
+    dispatcher.queue(123);
+    dispatcher.process();
+}


### PR DESCRIPTION
## Info
Replaced the list in favour of queue as it is perfectly made for this use-case. Should improve performance.

Also, this allows to queue new elements inside a queueDispatch callback.

Btw, thanks for this lib, had _exactly_ this in mind and found it then, saved me a ton of work.